### PR TITLE
fix: Request to update twitter to x icon

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -38,8 +38,8 @@
       "url": "https://github.com/tscircuit/tscircuit"
     },
     {
-      "name": "Twitter",
-      "icon": "twitter",
+      "name": "Twitter/X",
+      "icon": "x",
       "url": "https://twitter.com/tscircuit"
     },
     {
@@ -105,7 +105,7 @@
     }
   ],
   "footerSocials": {
-    "twitter": "https://twitter.com/tscircuit",
+    "x": "https://twitter.com/tscircuit",
     "github": "https://github.com/tscircuit/tscircuit",
     "linkedin": "https://www.linkedin.com/company/mintsearch"
   }


### PR DESCRIPTION
The Twitter logo has been changed and hasn't been updated on this site. [Fixes #27]

After changes
<img width="187" alt="Screenshot 2024-10-19 at 2 02 49 AM" src="https://github.com/user-attachments/assets/1b544217-f582-4e4e-93d3-2883a965f515">
<img width="178" alt="Screenshot 2024-10-19 at 2 02 52 AM" src="https://github.com/user-attachments/assets/cada3cc0-eb77-4671-85aa-88a6bffdb25b">
