### PR TITLE
Typo and Terminology Clarification in Trace Description

### DIFF
--- a/api-reference/components/trace.mdx
+++ b/api-reference/components/trace.mdx
@@ -2,7 +2,4 @@
 title: '<trace />'
 ---
 
-A trace establishes that two or more ports should be connected on both a
-schematic and PCB. After a trace is comleted, the auto-routing of your current
-layout engine will attempt to connect the two ports on both the PCB and
-Schematic.
+A trace establishes a connection between two or more ports in both the schematic and PCB. Once a trace is completed, the auto-routing feature of your layout engine will attempt to route the connection between the two ports in both the schematic and the PCB.


### PR DESCRIPTION
fix typo and terminology clarification in trace description
close #45 
fix: typo in complete word

![Image](https://github.com/user-attachments/assets/92b04466-f4d2-4206-afd7-2e2943364136)
