### PR TITLE
fix: incorrect linkedin url

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -112,6 +112,6 @@
   "footerSocials": {
     "x": "https://x.com/tscircuit",
     "github": "https://github.com/tscircuit/tscircuit",
-    "linkedin": "https://www.linkedin.com/company/mintsearch"
+    "linkedin": "https://www.linkedin.com/company/tscircuit"
   }
 }


### PR DESCRIPTION
### Description: 

On our documentation site, we have linked our socials in footer. While exploring I found a little issue - we have incorrect linkedIn URL. This PR fixes #48  

### Notes for reviewers: 

Nothing specific. 

### Is this tested on local? 

Yes

/claim #48

Thanks for adding the bounty 💙 happy to contribute